### PR TITLE
Use immutable settings slice

### DIFF
--- a/bindings/rust/src/bindings/generated.rs
+++ b/bindings/rust/src/bindings/generated.rs
@@ -79,11 +79,11 @@ pub struct KZGSettings {
     #[doc = " The length of `roots_of_unity`, a power of 2."]
     max_width: u64,
     #[doc = " Powers of the primitive root of unity determined by\n `SCALE2_ROOT_OF_UNITY` in bit-reversal permutation order,\n length `max_width`."]
-    roots_of_unity: *mut fr_t,
+    roots_of_unity: *const fr_t,
     #[doc = " G1 group elements from the trusted setup,\n in Lagrange form bit-reversal permutation."]
-    g1_values: *mut g1_t,
+    g1_values: *const g1_t,
     #[doc = " G2 group elements from the trusted setup."]
-    g2_values: *mut g2_t,
+    g2_values: *const g2_t,
 }
 extern "C" {
     pub fn load_trusted_setup(

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -119,7 +119,7 @@ pub fn hex_to_bytes(hex_str: &str) -> Result<Vec<u8>, Error> {
 
 /// Holds the parameters of a kzg trusted setup ceremony.
 impl KZGSettings {
-    pub fn from_u8_slice(data: &mut [u8]) -> Self {
+    pub fn from_u8_slice(data: &[u8]) -> Self {
         let size_max_length = core::mem::size_of::<u64>();
         let max_width: u64 = u64::from_be_bytes(data[0..size_max_length].try_into().unwrap());
 
@@ -128,9 +128,9 @@ impl KZGSettings {
 
         Self {
             max_width,
-            roots_of_unity: data[size_max_length..].as_mut_ptr() as *mut fr_t,
-            g1_values: data[size_max_length + size_roots_of_unity..].as_mut_ptr() as *mut blst_p1,
-            g2_values: data[size_max_length + size_roots_of_unity + size_g1_values..].as_mut_ptr()
+            roots_of_unity: data[size_max_length..].as_ptr() as *mut fr_t,
+            g1_values: data[size_max_length + size_roots_of_unity..].as_ptr() as *mut blst_p1,
+            g2_values: data[size_max_length + size_roots_of_unity + size_g1_values..].as_ptr()
                 as *mut blst_p2,
         }
     }

--- a/bindings/rust/src/ethereum_kzg_settings/mod.rs
+++ b/bindings/rust/src/ethereum_kzg_settings/mod.rs
@@ -1,30 +1,24 @@
-use crate::{
-    KzgSettings,
-};
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use once_cell::race::OnceBox;
+use crate::KzgSettings;
+use alloc::sync::Arc;
+use once_cell::sync::Lazy;
 
-/// Returns default Ethereum mainnet KZG settings.
+static RAW_KZG_SETTINGS: &[u8] = include_bytes!("./kzg_settings_raw.bin");
+
+static ETHEREUM_KZG_SETTINGS: Lazy<Arc<KzgSettings>> =
+    Lazy::new(|| Arc::new(KzgSettings::from_u8_slice(RAW_KZG_SETTINGS)));
+
+/// Returns the default Ethereum mainnet KZG settings.
 ///
 /// If you need a cloneable settings use `ethereum_kzg_settings_arc` instead.
 pub fn ethereum_kzg_settings() -> &'static KzgSettings {
-    ethereum_kzg_settings_inner().as_ref()
+    ETHEREUM_KZG_SETTINGS.as_ref()
 }
 
 /// Returns default Ethereum mainnet KZG settings as an `Arc`.
 ///
 /// It is useful for sharing the settings in multiple places.
 pub fn ethereum_kzg_settings_arc() -> Arc<KzgSettings> {
-    ethereum_kzg_settings_inner().clone()
-}
-
-fn ethereum_kzg_settings_inner() -> &'static Arc<KzgSettings> {
-    static DEFAULT: OnceBox<(Vec<u8>, Arc<KzgSettings>)> = OnceBox::new();
-    &DEFAULT.get_or_init(|| {
-        let mut data = Vec::from(include_bytes!("./kzg_settings_raw.bin"));
-        let settings = KzgSettings::from_u8_slice(data.as_mut_slice());
-        Box::new((data, Arc::new(settings)))
-    }).1
+    ETHEREUM_KZG_SETTINGS.clone()
 }
 
 #[cfg(test)]

--- a/src/c_kzg_4844.h
+++ b/src/c_kzg_4844.h
@@ -111,12 +111,12 @@ typedef struct {
     /** Powers of the primitive root of unity determined by
      * `SCALE2_ROOT_OF_UNITY` in bit-reversal permutation order,
      * length `max_width`. */
-    fr_t *roots_of_unity;
+    const fr_t *roots_of_unity;
     /** G1 group elements from the trusted setup,
      * in Lagrange form bit-reversal permutation. */
-    g1_t *g1_values;
+    const g1_t *g1_values;
     /** G2 group elements from the trusted setup. */
-    g2_t *g2_values;
+    const g2_t *g2_values;
 } KZGSettings;
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR refactors the `KZGSettings::from_u8_slice` API so that it can operate directly on an immutable slice. By doing so, we avoid copying a large chunk of data from the `include_bytes!` output into a mutable buffer during initialization. This change reduces the memory overhead and improves the startup performance by leveraging static data directly.